### PR TITLE
Disable for Rubinius

### DIFF
--- a/ext/system_timer/system_timer_native.c
+++ b/ext/system_timer/system_timer_native.c
@@ -16,6 +16,10 @@
 #define MINIMUM_TIMER_INTERVAL_IN_SECONDS 0.2
 
 VALUE rb_cSystemTimer;
+
+// Ignore most of this for Rubinius
+#ifndef RUBINIUS
+
 sigset_t original_mask;
 sigset_t sigalarm_mask;
 struct sigaction original_signal_handler;
@@ -297,6 +301,7 @@ static void set_itimerval(struct itimerval *value, double seconds) {
     return;
 }
 
+
 void Init_system_timer_native() 
 {
     init_sigalarm_mask();
@@ -308,3 +313,13 @@ void Init_system_timer_native()
     rb_define_singleton_method(rb_cSystemTimer, "enable_debug", 	enable_debug, 0);
     rb_define_singleton_method(rb_cSystemTimer, "disable_debug",	disable_debug, 0);
 }
+
+#else
+
+// Exists just to make things happy
+void Init_system_timer_native()
+{
+  rb_cSystemTimer = rb_define_module("SystemTimer");
+}
+
+#endif

--- a/lib/system_timer.rb
+++ b/lib/system_timer.rb
@@ -1,5 +1,9 @@
 # Copyright 2008 David Vollbracht & Philippe Hanrigou
 
+if defined?(RUBY_ENGINE) and RUBY_ENGINE == "rbx"
+  require File.dirname(__FILE__) + '/system_timer_stub'
+else
+
 require 'rubygems'
 require 'timeout'
 require 'forwardable'
@@ -106,3 +110,6 @@ module SystemTimer
 end
 
 require 'system_timer_native'
+
+
+end # stub guard


### PR DESCRIPTION
Hi ph7,

Rubinius doesn't require the functionality of SystemTimer because it does not have the timing issues that MRI 1.8 has. I've changed SystemTimer to use the stub version on Rubinius and to compile a minimal extension. The tests don't pass because they expect all the internals that the stub doesn't define, but that seems ok.

Thanks!
