### PR TITLE
Fix for RubyGems 1.6, which will not require thread for you

### DIFF
--- a/lib/system_timer.rb
+++ b/lib/system_timer.rb
@@ -56,7 +56,7 @@ module SystemTimer
         else
           install_next_timer timer_interval
         end
-     end
+      end
       return yield
     ensure
       @monitor.synchronize do

--- a/lib/system_timer.rb
+++ b/lib/system_timer.rb
@@ -4,7 +4,6 @@ if defined?(RUBY_ENGINE) and RUBY_ENGINE == "rbx"
   require File.dirname(__FILE__) + '/system_timer_stub'
 else
 
-require 'rubygems'
 require 'timeout'
 require 'forwardable'
 require 'monitor'

--- a/lib/system_timer.rb
+++ b/lib/system_timer.rb
@@ -4,6 +4,7 @@ if defined?(RUBY_ENGINE) and RUBY_ENGINE == "rbx"
   require File.dirname(__FILE__) + '/system_timer_stub'
 else
 
+require 'thread'
 require 'timeout'
 require 'forwardable'
 require 'monitor'

--- a/lib/system_timer_stub.rb
+++ b/lib/system_timer_stub.rb
@@ -1,6 +1,5 @@
 # Copyright 2008 David Vollbracht & Philippe Hanrigou
 
-require 'rubygems'
 require 'timeout'
 
 module SystemTimer 


### PR DESCRIPTION
When RubyGems 1.6 is released, then SystemTimer will break when it is loaded, as rubygems.rb no longer loads the thread extensions, resulting in the following error:

```
/opt/local/lib/ruby/gems/1.8/gems/SystemTimer-1.2/lib/system_timer.rb:33: undefined method `exclusive' for Thread:Class (NoMethodError)
```

There are also two less important commits included that fix a minor idiom and whitespace.

Thanks!
